### PR TITLE
interfacer: Allow interfacer to find content_service

### DIFF
--- a/interfacer.te
+++ b/interfacer.te
@@ -57,6 +57,7 @@ allow interfacer media_rw_data_file:file rw_file_perms;
 # Services
 allow interfacer activity_service:service_manager find;
 allow interfacer connectivity_service:service_manager find;
+allow interfacer content_service:service_manager find;
 allow interfacer display_service:service_manager find;
 allow interfacer mount_service:service_manager find;
 allow interfacer network_management_service:service_manager find;


### PR DESCRIPTION
https://substratum.review/#/c/420/ implements a ContentObserver in
interfacer which requires interfacer to be able to find the content_service.

Change-Id: I1d8cabd9848807ea4dfafcf7123478da834ef5a5